### PR TITLE
Fix inline code parsing

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -27,33 +27,33 @@ function parser(text) {
           return parseTitles(item, item2)
         }) // h6 tag
         .replace(/^----$/gim, '<hr>') // hr tag
-        .replace(/\_(.*?)\_/gim, '<em>$1</em>') // em text
-        .replace(/\*(.*?)\*/gim, '<strong>$1</strong>') // strong text
+        .replace(/^\+ (.*$)/gim, '<ol><li>$1</li></ol>\n\n') // strike text
+        .replace(/^\? (.*) : (.*$)/gim, '<dl><dt>$1</dt><dd>$2</dd></dl>\n\n') // strike text
+        .replace(/^- (.*$)/gim, '<ul><li>$1</li></ul>\n\n') // strike text
         .replace(/\`(.*?)\`/gim, function (char, item) {
           if (item.includes('<')) {
             return `<code>${item.replace(/</g, '<span><</span>')}</code>`
           } else {
             return `<code>${item}</code>`
           }
-        }) // strong text
-        .replace(/\~(.*?)\~/gim, '<del>$1</del>') // strike text
-        .replace(/^- (.*$)/gim, '<ul><li>$1</li></ul>\n\n') // strike text
-        .replace(/^\+ (.*$)/gim, '<ol><li>$1</li></ol>\n\n') // strike text
-        .replace(/^\? (.*) : (.*$)/gim, '<dl><dt>$1</dt><dd>$2</dd></dl>\n\n') // strike text
-        .replace(/\(link:(.*?)\)/gim, function (char, item) {
+        }) // inline code text
+        .replace(/(?<!<code>.+?)\_(.*?)\_(?!.+?<\/code>)/gim, '<em>$1</em>') // em text
+        .replace(/(?<!<code>.+?)\*(.*?)\*(?!.+?<\/code>)/gim, '<strong>$1</strong>') // strong text
+        .replace(/(?<!<code>.+?)\~(.*?)\~(?!.+?<\/code>)/gim, '<del>$1</del>') // strike text
+        .replace(/(?<!<code>.+?)\(link:(.*?)\)(?!.+?<\/code>)/gim, function (char, item) {
           return parseLinks(item)
         }) // links
-        .replace(/\(image:(.*?)\)/gim, function (char, item) {
+        .replace(/(?<!<code>.+?)\(image:(.*?)\)(?!.+?<\/code>)/gim, function (char, item) {
           return parseImage(item)
         }) // image
-        .replace(/\(video:(.*?)\)/gim, function (char, item) {
+        .replace(/(?<!<code>.+?)\(video:(.*?)\)(?!.+?<\/code>)/gim, function (char, item) {
           return parseVideo(item)
         }) // links
-        .replace(/\(audio:(.*?)\)/gim, function (char, item) {
+        .replace(/(?<!<code>.+?)\(audio:(.*?)\)(?!.+?<\/code>)/gim, function (char, item) {
           const mp3 = item.trim()
           return `<audio controls src="${mp3}" type="audio/mpeg" preload="metadata"></audio>`
         }) // links
-        .replace(/\(quote:(.*)\)/gim, function (char, item) {
+        .replace(/(?<!<code>.+?)\(quote:(.*)\)(?!.+?<\/code>)/gim, function (char, item) {
           return parseQuote(item)
         }) // blockquote
 
@@ -189,6 +189,7 @@ function toKebab(text) {
     .join('-')
   return toKebabCase
 }
+
 export {
   parser as
   default

--- a/src/parser.js
+++ b/src/parser.js
@@ -27,33 +27,33 @@ function parser(text) {
                     return parseTitles(item, item2)
                 }) // h6 tag
                 .replace(/^----$/gim, '<hr>') // hr tag
-                .replace(/\_(.*?)\_/gim, '<em>$1</em>') // em text
-                .replace(/\*(.*?)\*/gim, '<strong>$1</strong>') // strong text
+                .replace(/^\+ (.*$)/gim, '<ol><li>$1</li></ol>\n\n') // strike text
+                .replace(/^\? (.*) : (.*$)/gim, '<dl><dt>$1</dt><dd>$2</dd></dl>\n\n') // strike text
+                .replace(/^- (.*$)/gim, '<ul><li>$1</li></ul>\n\n') // strike text
                 .replace(/\`(.*?)\`/gim, function (char, item) {
                     if (item.includes('<')) {
                         return `<code>${item.replace(/</g, '<span><</span>')}</code>`
                     } else {
                         return `<code>${item}</code>`
                     }
-                }) // strong text
-                .replace(/\~(.*?)\~/gim, '<del>$1</del>') // strike text
-                .replace(/^- (.*$)/gim, '<ul><li>$1</li></ul>\n\n') // strike text
-                .replace(/^\+ (.*$)/gim, '<ol><li>$1</li></ol>\n\n') // strike text
-                .replace(/^\? (.*) : (.*$)/gim, '<dl><dt>$1</dt><dd>$2</dd></dl>\n\n') // strike text
-                .replace(/\(link:(.*?)\)/gim, function (char, item) {
+                }) // inline code text
+                .replace(/(?<!<code>.+?)\_(.*?)\_(?!.+?<\/code>)/gim, '<em>$1</em>') // em text
+                .replace(/(?<!<code>.+?)\*(.*?)\*(?!.+?<\/code>)/gim, '<strong>$1</strong>') // strong text
+                .replace(/(?<!<code>.+?)\~(.*?)\~(?!.+?<\/code>)/gim, '<del>$1</del>') // strike text
+                .replace(/(?<!<code>.+?)\(link:(.*?)\)(?!.+?<\/code>)/gim, function (char, item) {
                     return parseLinks(item)
                 }) // links
-                .replace(/\(image:(.*?)\)/gim, function (char, item) {
+                .replace(/(?<!<code>.+?)\(image:(.*?)\)(?!.+?<\/code>)/gim, function (char, item) {
                     return parseImage(item)
                 }) // image
-                .replace(/\(video:(.*?)\)/gim, function (char, item) {
+                .replace(/(?<!<code>.+?)\(video:(.*?)\)(?!.+?<\/code>)/gim, function (char, item) {
                     return parseVideo(item)
                 }) // links
-                .replace(/\(audio:(.*?)\)/gim, function (char, item) {
-                    const mp3 = item.trim()
+                .replace(/(?<!<code>.+?)\(audio:(.*?)\)(?!.+?<\/code>)/gim, function (char, item) {
+                const mp3 = item.trim()
                     return `<audio controls src="${mp3}" type="audio/mpeg" preload="metadata"></audio>`
                 }) // links
-                .replace(/\(quote:(.*)\)/gim, function (char, item) {
+                .replace(/(?<!<code>.+?)\(quote:(.*)\)(?!.+?<\/code>)/gim, function (char, item) {
                     return parseQuote(item)
                 }) // blockquote
 

--- a/test.js
+++ b/test.js
@@ -69,9 +69,9 @@ test('paragraph', t => {
 
 // INLINE CODE
 
-test('inline code with italics', t => {
-	const result = parser('`footer__link`');
-	t.is(result, "<code>footer__link</code>");
+test('inline code', t => {
+	const result = parser('`footer__link (link: link_url text: textlink) Sometimes with *bold* inside.`');
+	t.is(result, "<code>footer__link (link: link_url text: textlink) Sometimes with *bold* inside.</code>");
 });
 
 // CODE BLOCK

--- a/test.js
+++ b/test.js
@@ -67,6 +67,13 @@ test('paragraph', t => {
 	t.is(result, "<p>I am a line</p>\n\n<p>I'm a second line</p>\n\n");
 });
 
+// INLINE CODE
+
+test('inline code with italics', t => {
+	const result = parser('`footer__link`');
+	t.is(result, "<code>footer__link</code>");
+});
+
 // CODE BLOCK
 
 test('code block', t => {


### PR DESCRIPTION
I saw in [an article](https://thomasorus.com/css-methodologies.html) on your RSS feed, there were a few times inline code blocks were parsing `__` as `<em></em>`, which I assumed was not a desired effect. I had just recently been working on parsers and thought it would be a good puzzle.

I added lookbehinds/lookaheads to inline elements to check for if it was in a code block, and if so, skip.